### PR TITLE
Break Chitti PRD into implementable issues

### DIFF
--- a/.scratch/chitti-app/issues/01-app-scaffold-skeleton.md
+++ b/.scratch/chitti-app/issues/01-app-scaffold-skeleton.md
@@ -1,0 +1,47 @@
+Status: ready-for-human
+
+# 01 — Walking skeleton: Compose app + Hilt + Room + foreground service
+
+## What to build
+
+The greenfield foundation every other Chitti slice builds on. A Kotlin +
+Jetpack Compose Android app that launches to a placeholder `KidHomeScreen`, with
+Hilt dependency injection wired up, a Room database initialised with the root
+`ChildProfile` entity and a `ProfileRepository`, a `NotificationService`
+(`ForegroundService`) that shows a persistent "Chitti is running" notification,
+and an `AlarmScheduler` utility skeleton that all later alarm registrations route
+through.
+
+The Room schema is multi-child ready from day one (`ChildProfile` is the root;
+later entities carry a `childId` foreign key) but the UI is single-child for MVP.
+
+This is a HITL slice: it requires the project to be created, the Gradle/SDK
+toolchain chosen, and a first run on a device confirmed by the developer.
+
+## Acceptance criteria
+
+- [ ] App builds and launches to a placeholder `KidHomeScreen` composable
+- [ ] Hilt is configured (`@HiltAndroidApp` application, an injectable repository)
+- [ ] Room DB created with `ChildProfile` entity + `ProfileRepository`; schema is
+      designed multi-child (foreign-key ready) per PRD `LocalDatabase`
+- [ ] `NotificationService` runs as a `ForegroundService` with a persistent
+      "Chitti is running" notification
+- [ ] `AlarmScheduler` utility exists as the single entry point for alarm
+      registration (skeleton; concrete alarms added in later slices)
+- [ ] Key dependencies declared: `lottie-compose`, Room, Hilt, Retrofit+OkHttp,
+      Jetpack Security
+
+## Blocked by
+
+None - can start immediately.
+
+## Open questions
+
+- **Build/test environment (blocking):** Confirm how slices are verified —
+  developer-on-device (per the design doc's "agent writes code, developer
+  tests") or an automated build in CI. The remote agent environment may not have
+  the Android SDK/Gradle to compile, which affects every downstream slice's
+  verification story.
+- **min/target SDK:** Not specified in the PRD. Required before manifest work —
+  the `FOREGROUND_SERVICE_*` subtype permission (slice 03) depends on the target
+  SDK level. Please pin both.

--- a/.scratch/chitti-app/issues/02-parent-pin-and-child-profile.md
+++ b/.scratch/chitti-app/issues/02-parent-pin-and-child-profile.md
@@ -1,0 +1,33 @@
+Status: ready-for-agent
+
+# 02 — Parent PIN gate + child profile creation
+
+## What to build
+
+The PIN-gated entry to the parent area and first-run child profile setup. A
+`PINGuard` validates a PIN before any parent screen is shown; the PIN is stored
+as a bcrypt hash in `EncryptedSharedPreferences` (Jetpack Security), never in
+plain text, defaulting to `0000` on first install. The parent can create a
+`ChildProfile` with a name and age so Chitti can personalise interactions.
+
+MVP PIN recovery is reinstall-only (resets to `0000`); email/security-question
+recovery is out of scope.
+
+## Acceptance criteria
+
+- [ ] Parent area is gated by a PIN entry dialog shown on every parent-screen
+      entry
+- [ ] PIN stored as a bcrypt hash in `EncryptedSharedPreferences`; no plain-text
+      PIN written to disk
+- [ ] Default PIN is `0000` on first install
+- [ ] Parent can set/change the PIN
+- [ ] Parent can create a `ChildProfile` (name, age), persisted in Room
+- [ ] Incorrect PIN is rejected; correct PIN unlocks the parent area
+
+## Blocked by
+
+- 01 — app scaffold (Room, Hilt, parent navigation shell)
+
+## Open questions
+
+None — covered by PRD "PIN Storage" section.

--- a/.scratch/chitti-app/issues/03-permissions-onboarding-health-check.md
+++ b/.scratch/chitti-app/issues/03-permissions-onboarding-health-check.md
@@ -1,0 +1,35 @@
+Status: ready-for-agent
+
+# 03 — Permission onboarding + Permission Health Check
+
+## What to build
+
+An onboarding flow that walks the parent through granting the MVP runtime/manifest
+permissions, plus a Permission Health Check screen that detects any of them being
+revoked later and guides the parent to re-enable them — so the app keeps working
+reliably after setup.
+
+MVP permissions:
+- `POST_NOTIFICATIONS` — task reminders and screen time warnings
+- `FOREGROUND_SERVICE` (+ the `FOREGROUND_SERVICE_*` subtype required by the
+  target SDK) — persistent timer/reminder service
+- `RECEIVE_BOOT_COMPLETED` — re-register alarms and restart the service on reboot
+- `RECORD_AUDIO` — child voice input (wake word + utterance capture)
+
+## Acceptance criteria
+
+- [ ] Onboarding requests each permission with a child-friendly rationale
+- [ ] Permission Health Check screen lists each permission's current granted state
+- [ ] When a required permission is revoked, the screen flags it and routes the
+      parent to re-enable it
+- [ ] App degrades gracefully (does not crash) when a permission is missing
+
+## Blocked by
+
+- 01 — app scaffold (manifest, foreground service)
+- 02 — parent area (health check lives behind the PIN gate)
+
+## Open questions
+
+- **target SDK (blocking, shared with 01):** the exact `FOREGROUND_SERVICE_*`
+  subtype permission to declare depends on the pinned target SDK. Resolve in 01.

--- a/.scratch/chitti-app/issues/04-parent-task-crud.md
+++ b/.scratch/chitti-app/issues/04-parent-task-crud.md
@@ -1,0 +1,35 @@
+Status: ready-for-agent
+
+# 04 — Parent task CRUD + scheduling model
+
+## What to build
+
+The parent-facing task management surface and its data model. `Task` and
+`TaskSchedule` Room entities (with a `TaskRepository`) and a Parent Task List +
+Task Editor UI that lets a parent create, edit, delete, and toggle tasks
+active/inactive. Each task has a name, estimated duration, a point value, and a
+schedule: repeat daily, on specific weekdays, or on custom days, plus a fixed
+time of day.
+
+This slice owns the schedule model and CRUD only. Alarm registration on save is
+added in slice 07 (routed through `AlarmScheduler`); this slice may call into the
+scheduler as a no-op stub.
+
+## Acceptance criteria
+
+- [ ] Parent can create a task with name, duration, point value, schedule, and
+      fixed time
+- [ ] Schedule supports daily, specific-weekday, and custom-day repetition
+- [ ] Parent can edit and delete tasks
+- [ ] Parent can toggle a task active/inactive without deleting it
+- [ ] Tasks and schedules persist in Room via `TaskRepository`
+- [ ] Task list reflects active/inactive state
+
+## Blocked by
+
+- 01 — app scaffold (Room, Hilt)
+- 02 — parent area (PIN gate, navigation)
+
+## Open questions
+
+None — covered by PRD user stories 17–22 and the `TaskEngine` interface.

--- a/.scratch/chitti-app/issues/05-kid-home-today-tasks-points.md
+++ b/.scratch/chitti-app/issues/05-kid-home-today-tasks-points.md
@@ -1,0 +1,40 @@
+Status: ready-for-agent
+
+# 05 — Kid home: today's tasks + mark done + points (honor system)
+
+## What to build
+
+The core child loop. `KidHomeScreen` shows today's pending task checklist; the
+child taps "Done" to complete a task (honor system), which records a completion
+and immediately awards points. The screen shows two distinct figures: points
+earned today and current points balance.
+
+`TaskEngine.getPendingToday()` returns **all** tasks scheduled for today's
+day-of-week that are not yet completed, regardless of time of day (so the child
+sees later-today tasks too). `markComplete(taskId)` records a completion
+timestamp and must not re-surface the same task as pending for the same day.
+`RewardSystem` maintains a single append-only points ledger (`PointTransaction`):
+`awardPoints` writes positive rows, `getBalance()` is the running sum,
+`getEarnedToday()` sums only positive rows dated today.
+
+The "today" boundary is midnight (00:00) rollover.
+
+## Acceptance criteria
+
+- [ ] `getPendingToday()` returns all of today's not-yet-completed scheduled
+      tasks regardless of time of day
+- [ ] Each task row shows name, estimated duration, and a "Done" button
+- [ ] Tapping "Done" calls `markComplete`, records a `TaskCompletion`, and awards
+      the task's points via `awardPoints`
+- [ ] A completed task does not re-appear as pending for the same day
+- [ ] Home screen shows points-earned-today and current balance as two figures
+- [ ] Ledger is append-only; `getBalance()` reflects the running sum;
+      `getEarnedToday()` counts only today's positive rows
+
+## Blocked by
+
+- 04 — task model + CRUD
+
+## Open questions
+
+None.

--- a/.scratch/chitti-app/issues/06-upcoming-tasks-preview.md
+++ b/.scratch/chitti-app/issues/06-upcoming-tasks-preview.md
@@ -1,0 +1,25 @@
+Status: ready-for-agent
+
+# 06 — Upcoming tasks preview
+
+## What to build
+
+A child-facing preview of upcoming tasks for the next few days so the child can
+plan ahead. `TaskEngine.getUpcoming(days: Int)` computes the scheduled tasks for
+the next 7 days from the schedule rules, surfaced as an "upcoming" tab on
+`KidHomeScreen`.
+
+## Acceptance criteria
+
+- [ ] `getUpcoming(7)` returns scheduled tasks for the next 7 days derived from
+      schedule rules
+- [ ] `KidHomeScreen` has an upcoming tab showing these grouped by day
+- [ ] Inactive tasks are excluded from the upcoming list
+
+## Blocked by
+
+- 05 — kid home + task engine
+
+## Open questions
+
+None.

--- a/.scratch/chitti-app/issues/07-task-reminders-alarms-escalation.md
+++ b/.scratch/chitti-app/issues/07-task-reminders-alarms-escalation.md
@@ -1,0 +1,45 @@
+Status: ready-for-agent
+
+# 07 — Task reminders: alarms + tiered notification + escalation
+
+## What to build
+
+The full task reminder flow. When a task is saved or modified, `TaskEngine`
+registers/cancels an exact alarm via `AlarmScheduler`
+(`setExactAndAllowWhileIdle()` for Doze). On fire, `NotificationService` posts a
+high-priority task-reminder notification. If the child does not acknowledge
+within 5 minutes, a secondary escalation alarm (owned by `NotificationService`)
+launches `ChittiFullScreenActivity` with the task prompt and a "Mark Done" button.
+`TaskEngine.markComplete()` cancels the pending escalation alarm.
+
+Single owner for escalation: `NotificationService` schedules and cancels the
+5-minute escalation; `TaskEngine` does not. Edge cases: device off at task time →
+fire on next boot, but **skip if more than 2 hours past due**; two tasks at the
+same time fire as independent alarms. A `RECEIVE_BOOT_COMPLETED` BootReceiver
+re-registers all active task alarms and restarts the foreground service on boot.
+
+Data flow: `AlarmManager` → `NotificationService` posts notification → (5 min, no
+ack) → escalation alarm → `ChittiFullScreenActivity` → `markComplete()` →
+`awardPoints()` → (celebration handled in slice 08).
+
+## Acceptance criteria
+
+- [ ] Saving/modifying a task registers/cancels its exact alarm via
+      `AlarmScheduler` using `setExactAndAllowWhileIdle()`
+- [ ] On alarm fire, a high-priority task-reminder notification is posted
+- [ ] If unacknowledged after 5 min, escalation launches
+      `ChittiFullScreenActivity` with a "Mark Done" button
+- [ ] `markComplete()` cancels the pending escalation alarm
+- [ ] A task missed by > 2 hours on boot is skipped, not fired
+- [ ] Two tasks at the same time fire independently
+- [ ] BootReceiver re-registers active task alarms and restarts the foreground
+      service after reboot
+
+## Blocked by
+
+- 05 — kid home, `markComplete`, reward award
+
+## Open questions
+
+None — escalation ownership and edge cases are specified in PRD `TaskEngine` /
+`NotificationService`.

--- a/.scratch/chitti-app/issues/08-chitti-character-lottie-tts.md
+++ b/.scratch/chitti-app/issues/08-chitti-character-lottie-tts.md
@@ -1,0 +1,55 @@
+Status: needs-info
+
+# 08 — ChittiCharacter: Lottie states + TTS + celebration
+
+## What to build
+
+The Chitti character module: a Lottie animation player managing named states
+(`idle`, `talking`, `celebrating`, `warning`), a rule-based adaptive-tone engine
+mapping the `ChittiContext` enum to a tone + animation state, and a TTS wrapper
+around Android `TextToSpeech` behind a swappable interface (for future cloud TTS)
+that caches frequently used phrases as audio files. On task completion, Chitti
+plays the celebration sequence with voice.
+
+```kotlin
+enum class ChittiContext {
+    TASK_REMINDER,   // → encouraging tone, attentive animation
+    TASK_COMPLETE,   // → energetic tone, celebration animation
+    SCREEN_WARNING,  // → calm tone, gentle warning animation
+    SCREEN_CUTOFF,   // → calm tone, time's-up animation
+    QNA,             // → calm/curious tone, talking animation
+    IDLE             // → calm & wise (default), idle animation
+}
+```
+
+Interface: `speak(text: String, context: ChittiContext)` and
+`animate(state: ChittiState)`.
+
+## Acceptance criteria
+
+- [ ] Lottie player renders and switches between idle/talking/celebrating/warning
+- [ ] `ChittiContext` maps to the correct tone + animation state per the table
+- [ ] TTS wrapper speaks text behind a swappable interface; frequently used
+      phrases are cached as audio files
+- [ ] Task completion triggers the celebration animation + voice
+      (`ChittiContext.TASK_COMPLETE`)
+
+## Blocked by
+
+- 01 — app scaffold (`lottie-compose`, TTS init)
+- 05 — task completion event source
+
+## Open questions
+
+- **Lottie assets (non-blocking):** which placeholder Lottie character file and
+  how its named states map to the four states. PRD permits a free placeholder
+  with file names as the only coupling point — implement against a chosen
+  placeholder and document the mapping. (Custom artwork swaps in later without
+  code changes.)
+- **Phrase strings (non-blocking):** exact reminder/celebration/warning/cutoff
+  copy is unspecified. Author age-appropriate defaults; confirm wording with the
+  product owner.
+
+> Status is `needs-info` only pending confirmation of the placeholder asset to
+> build against. If the team is happy for the implementing agent to pick a free
+> placeholder and document it, this can be flipped to `ready-for-agent`.

--- a/.scratch/chitti-app/issues/09-reward-badges-costumes.md
+++ b/.scratch/chitti-app/issues/09-reward-badges-costumes.md
@@ -1,0 +1,43 @@
+Status: needs-info
+
+# 09 — Reward system: badges, costumes, costume selector
+
+## What to build
+
+The motivation layer on top of the points ledger. Badge and costume unlocks are
+evaluated against the **current balance** (single-balance model — no separate
+lifetime-earned total), so redeeming points can drop the balance below a
+threshold and remove access to a higher-tier unlock. `checkNewBadges()` returns
+newly crossed badges; `getUnlockedCostumes()` returns costumes whose milestone
+the current balance meets; `setActiveCostume()` persists the child's selection on
+`ChildProfile` and only succeeds for a currently-unlocked costume. `KidHomeScreen`
+shows badge count, current level, and a costume selector.
+
+## Acceptance criteria
+
+- [ ] Awarding points across a badge threshold makes `checkNewBadges()` return
+      the new badge
+- [ ] Points reaching a costume milestone makes `getUnlockedCostumes()` include
+      that costume
+- [ ] Single-balance rule: after a redemption drops the balance below a
+      milestone, `getUnlockedCostumes()` no longer returns that costume
+- [ ] `setActiveCostume()` persists the selection and succeeds only for a
+      currently-unlocked costume
+- [ ] `KidHomeScreen` shows badge count, level, and a working costume selector
+
+## Blocked by
+
+- 05 — points ledger (`awardPoints`, `getBalance`)
+- 08 — Chitti character (costume Lottie assets)
+
+## Open questions
+
+- **Badge & costume tables (blocking):** the PRD gives only examples
+  ("50pts = Bronze badge, 200pts = Silver"). The full static tables are required
+  to implement this slice:
+  - Badge tiers: names + point thresholds (complete list).
+  - Level rules: how levels map to points.
+  - Costume milestones: point thresholds → Lottie costume asset names.
+  Until these are supplied, the unlock logic cannot be finalised. This is why the
+  status is `needs-info`. Acceptance-criteria *logic* can be built against a
+  placeholder table, but the real values must be confirmed before merge.

--- a/.scratch/chitti-app/issues/10-screen-time-restrictions.md
+++ b/.scratch/chitti-app/issues/10-screen-time-restrictions.md
@@ -1,0 +1,53 @@
+Status: ready-for-agent
+
+# 10 — Screen-time restrictions: parent config + warning + block
+
+## What to build
+
+Device-wide, clock-based screen-time windows. A `ScreenTimeRule` Room entity
+(start time, end time, days active) with a `RestrictionRepository`, a Parent
+Screen Time Rules UI to configure windows, and automatic enforcement via
+`AlarmScheduler`: a 10-minute warning alarm and a hard-cutoff alarm per active
+window. The 10-minute warning fires a high-priority notification with
+`setFullScreenIntent` → `ChittiWarningActivity` (countdown + encouraging wrap-up
+message). The hard cutoff launches `ChittiBlockActivity` full-screen with a
+positive time's-up message.
+
+`checkCurrentlyRestricted()` returns true only inside a configured window on a
+matching day, evaluated correctly for windows spanning midnight (e.g. 10pm–7am).
+Deactivated rules are not evaluated. The BootReceiver from slice 07 is extended
+to re-register screen-time alarms on reboot.
+
+**Known MVP limitation:** without `SYSTEM_ALERT_WINDOW`, the child can exit
+`ChittiBlockActivity` via the Home button — this is a soft deterrent only, and
+parents are told so during onboarding. Full enforcement (overlay) is v2.
+
+## Acceptance criteria
+
+- [ ] Parent can configure a window (start, end, active days), persisted in Room
+- [ ] 10-min warning fires a `setFullScreenIntent` notification →
+      `ChittiWarningActivity` with countdown + wrap-up message
+- [ ] Hard cutoff launches `ChittiBlockActivity` full-screen with a positive
+      time's-up message
+- [ ] `checkCurrentlyRestricted()` is true only within a window on a matching day
+- [ ] A window spanning midnight is evaluated correctly on both sides
+- [ ] Deactivated rules are not evaluated
+- [ ] Screen-time alarms re-register on boot
+
+## Blocked by
+
+- 04 — parent area shell
+- 08 — Chitti character used in the warning/block activities
+
+## Open questions
+
+- **Re-launch policy (clarify):** without `PACKAGE_USAGE_STATS`, the block can
+  only fire at the cutoff alarm. If the child dismisses `ChittiBlockActivity` via
+  Home, the PRD's "soft deterrent" is silent on whether/when Chitti re-launches
+  (e.g. on app foreground, on a repeating alarm, or not at all). Confirm the
+  intended MVP behaviour.
+- **Design-vs-PRD conflict (note):** `plans/chitti-design.md` and
+  `plans/base-idea.md` describe an *activity gate* (eye exercises / jumping jacks
+  before the timer unlocks) on the block screen. The PRD explicitly lists the
+  activity gate as **out of scope (v2)**. This slice follows the PRD (no gate);
+  raised here in case the product owner intends otherwise.

--- a/.scratch/chitti-app/issues/11-reward-config-screen-time-redemption.md
+++ b/.scratch/chitti-app/issues/11-reward-config-screen-time-redemption.md
@@ -1,0 +1,39 @@
+Status: ready-for-agent
+
+# 11 — Reward config + screen-time redemption
+
+## What to build
+
+The optional closed loop that turns earned points into extra screen time. A
+`RewardConfig` Room entity holds the parent's settings: an enable/disable toggle
+for screen-time bonus redemption and the conversion rate (how many points equal
+how many extra minutes). A Parent Reward Config UI edits these. When enabled, the
+child taps a "Redeem" action on `KidHomeScreen`:
+`RewardSystem.redeemForScreenTime(points)` computes minutes at the configured
+rate, calls `ScreenTimeRestrictions.creditExtraMinutes(minutes)` (which moves the
+hard-cutoff alarm forward), and records a **negative** ledger row so the balance
+decreases by the redeemed points. Chitti celebrates the redemption.
+
+Redemption is unavailable (or hidden) when the parent toggle is off.
+
+## Acceptance criteria
+
+- [ ] Parent can toggle screen-time bonus on/off and set the points→minutes rate
+- [ ] With the toggle off, redemption is not available to the child
+- [ ] "Redeem" computes the correct minutes for the balance and configured rate
+- [ ] `creditExtraMinutes()` extends the effective cutoff time (cutoff alarm
+      rescheduled)
+- [ ] A negative ledger row is recorded; `getBalance()` decreases by the redeemed
+      points (ledger stays append-only)
+- [ ] Chitti celebrates on successful redemption
+
+## Blocked by
+
+- 09 — reward balance + ledger semantics
+- 10 — `creditExtraMinutes` / cutoff alarm
+
+## Open questions
+
+- **Default rate & bounds (non-blocking):** the PRD does not give a default
+  points→minutes rate or min/max bounds. Implement with a sensible default and
+  validation; confirm values with the product owner.

--- a/.scratch/chitti-app/issues/12a-qna-tap-to-talk.md
+++ b/.scratch/chitti-app/issues/12a-qna-tap-to-talk.md
@@ -1,0 +1,47 @@
+Status: needs-info
+
+# 12a — Q&A with Chitti (tap-to-talk)
+
+## What to build
+
+Multi-turn voice Q&A, using tap-on-character as the always-available entry point
+(wake word is slice 12b). Tapping Chitti opens a `QnAEngine` session; Android
+`SpeechRecognizer` captures the child's utterance. Online, the conversation
+history (last 6 exchanges) plus the new utterance is sent to the Claude API with
+a kid-safe system prompt; the response text is fed to Chitti's TTS. The session
+ends after 60 seconds of silence or a "bye Chitti" utterance.
+
+Offline / API-error / timeout path: pick from a bundled pool of pre-written
+fallback responses (≥ 20, covering curiosity, homework encouragement,
+feelings/emotions, and a generic "I don't know, let's find out together"). The
+category is chosen by a simple on-device keyword heuristic over the utterance,
+with the generic category as the fallback when nothing matches.
+
+Claude API integration: Retrofit + OkHttp; system prompt enforces age-appropriate
+language, no adult content, no personal-data collection, and responses ≤ 3
+sentences; 8-second timeout → offline fallback. API key injected via
+`BuildConfig` at build time (never committed; `CLAUDE_API_KEY` kept out of source
+control).
+
+## Acceptance criteria
+
+- [ ] Tapping the Chitti character starts a Q&A session
+- [ ] Utterance captured via `SpeechRecognizer`
+- [ ] Online: last 6 exchanges + utterance sent to Claude with the kid-safe
+      prompt; response spoken via TTS; responses ≤ 3 sentences
+- [ ] 8s timeout / offline / error → keyword-categorised fallback response, with
+      generic fallback when no category matches
+- [ ] Bundled pool has ≥ 20 responses across the four categories
+- [ ] Session ends after 60s silence or "bye Chitti"
+- [ ] API key sourced from `BuildConfig`; not present in source control
+
+## Blocked by
+
+- 08 — Chitti character (TTS, talking animation)
+
+## Open questions
+
+- **Claude API (blocking):** the exact model id, how the dev/test API key is
+  provisioned, and the exact kid-safe system-prompt text are not specified.
+  Needed before the online path can be implemented and tested. (The offline
+  fallback path can proceed independently.)

--- a/.scratch/chitti-app/issues/12b-qna-wake-word.md
+++ b/.scratch/chitti-app/issues/12b-qna-wake-word.md
@@ -1,0 +1,38 @@
+Status: needs-info
+
+# 12b — Q&A wake word ("Hey Chitti")
+
+## What to build
+
+Passive wake-word activation layered on top of the tap-to-talk Q&A (12a). A
+dedicated on-device wake-word engine detects "Hey Chitti" / "Hi Chitti" and opens
+a `QnAEngine` session; Android `SpeechRecognizer` then captures the utterance (it
+cannot reliably spot always-on wake words itself). Wake-word listening is active
+only while the screen is on, falling back to tap-to-talk when the app is
+backgrounded — to limit battery drain.
+
+## Acceptance criteria
+
+- [ ] Saying "Hey Chitti" / "Hi Chitti" with the screen on opens a Q&A session
+- [ ] After the wake word, the utterance is captured via `SpeechRecognizer` and
+      flows through the same Q&A path as 12a
+- [ ] Wake-word listening is disabled when the app is backgrounded; tap-to-talk
+      remains available
+- [ ] Battery impact is bounded (listening only while screen on)
+
+## Blocked by
+
+- 12a — Q&A session pipeline
+
+## Open questions
+
+- **Wake-word engine (blocking):** the PRD names Porcupine / Picovoice only as
+  examples ("e.g."). Required decisions before this can be built:
+  - Which engine, and its licensing / access-key model (Picovoice's free tier has
+    usage limits and the access key must be provisioned and kept out of source
+    control like the Claude key).
+  - Custom "Hey Chitti" / "Hi Chitti" keyword files must be trained/obtained for
+    the chosen engine.
+  This is why the status is `needs-info`. Consider whether wake word is required
+  for the MVP launch or can ship after, since tap-to-talk (12a) already provides
+  the full Q&A experience.

--- a/.scratch/chitti-app/issues/13-parent-dashboard-history-summary.md
+++ b/.scratch/chitti-app/issues/13-parent-dashboard-history-summary.md
@@ -1,0 +1,32 @@
+Status: ready-for-agent
+
+# 13 — Parent dashboard: history, weekly summary, periodic jobs
+
+## What to build
+
+The parent's visibility into the child's progress, plus the background jobs that
+keep derived data fresh. Inside the PIN-gated parent area: a Child History screen
+(completed vs. missed tasks), a Weekly Summary of completed/missed tasks for
+informed conversations, and the child's total points and badges earned.
+Non-time-critical periodic work runs via `WorkManager`: a daily badge check, a
+periodic history cleanup, and weekly summary generation. (Time-critical alarms
+remain on `AlarmManager` per the scheduling approach.)
+
+## Acceptance criteria
+
+- [ ] Child History screen shows completed and missed tasks
+- [ ] Weekly Summary aggregates completed/missed tasks for the week
+- [ ] Parent dashboard shows total points and badges earned
+- [ ] `WorkManager` runs a daily badge check, history cleanup, and weekly summary
+      generation
+- [ ] All of the above are behind the PIN gate
+
+## Blocked by
+
+- 05 — task completions + points ledger
+- 09 — badges
+
+## Open questions
+
+- **History cleanup retention (non-blocking):** the retention window for history
+  cleanup is unspecified. Implement with a sensible default and confirm.

--- a/.scratch/chitti-app/issues/README.md
+++ b/.scratch/chitti-app/issues/README.md
@@ -1,0 +1,53 @@
+# Chitti MVP — implementation issues
+
+Derived from `../PRD.md` as vertical tracer-bullet slices. Each issue file has a
+`Status:` line: `ready-for-agent` (fully specified, AFK-runnable),
+`ready-for-human` (needs human setup/decisions), or `needs-info` (blocked on an
+open question — see that issue's `## Open questions`).
+
+## Issue index & dependencies
+
+| # | Slice | Status | Blocked by | Stories |
+|---|---|---|---|---|
+| 01 | App scaffold / walking skeleton | ready-for-human | — | foundation |
+| 02 | Parent PIN gate + child profile | ready-for-agent | 01 | 29, 32 |
+| 03 | Permission onboarding + health check | ready-for-agent | 01, 02 | 30, 31 |
+| 04 | Parent task CRUD + scheduling model | ready-for-agent | 01, 02 | 17–22 |
+| 05 | Kid home: today's tasks + done + points | ready-for-agent | 04 | 1, 4, 6 |
+| 06 | Upcoming tasks preview | ready-for-agent | 05 | 2 |
+| 07 | Task reminders: alarms + escalation | ready-for-agent | 05 | 3 |
+| 08 | ChittiCharacter: Lottie + TTS | needs-info | 01, 05 | 5 |
+| 09 | Reward: badges, costumes, selector | needs-info | 05, 08 | 7, 8 |
+| 10 | Screen-time restrictions | ready-for-agent | 04, 08 | 9, 10, 11, 23, 24 |
+| 11 | Reward config + screen-time redemption | ready-for-agent | 09, 10 | 12, 25, 26 |
+| 12a | Q&A tap-to-talk (Claude + offline) | needs-info | 08 | 13, 14, 15, 16 |
+| 12b | Q&A wake word ("Hey Chitti") | needs-info | 12a | 13 |
+| 13 | Parent dashboard: history + summary | ready-for-agent | 05, 09 | 27, 28 |
+
+All 32 PRD user stories are covered. Dependencies form a DAG (build in numeric
+order).
+
+## Flagged ambiguities (blocking — resolve before the noted issue can merge)
+
+1. **Build/test environment + min/target SDK** (issue 01) — how slices are
+   verified (device vs CI) and the pinned SDK levels.
+2. **Badge / costume / level tables** (issue 09) — only examples in the PRD; need
+   the full threshold tables + costume asset names.
+3. **Claude API** (issue 12a) — model id, dev API-key provisioning, exact kid-safe
+   system-prompt text.
+4. **Wake-word engine** (issue 12b) — engine choice, licensing/access key, custom
+   "Hey Chitti" keyword training.
+5. **Lottie placeholder asset** (issue 08) — confirm the agent may pick a free
+   placeholder and document the state mapping.
+
+## Non-blocking flags (sensible defaults; confirm with product owner)
+
+- Chitti phrase copy (08), points→minutes default rate/bounds (11), screen-time
+  re-launch policy after Home-dismiss (10), history-cleanup retention (13).
+
+## Note: design-doc vs PRD conflict
+
+`plans/chitti-design.md` and `plans/base-idea.md` describe an **activity gate**
+(eye exercises / jumping jacks before the screen-time timer unlocks). The PRD
+lists this as **out of scope (v2)**. These issues follow the PRD (no gate); see
+issue 10 if the product owner intends otherwise.


### PR DESCRIPTION
Decompose .scratch/chitti-app/PRD.md into 14 vertical tracer-bullet
slices under .scratch/chitti-app/issues/, covering all 32 user stories.
Each issue carries a Status line and inline Open questions; blocking
ambiguities (build env/SDK, badge/costume tables, Claude API, wake-word
engine) are flagged needs-info. Includes a README index with the
coverage matrix and dependency DAG.